### PR TITLE
youtube-nocookie embed alternative

### DIFF
--- a/src/main/background.js
+++ b/src/main/background.js
@@ -1,4 +1,5 @@
 const YOUTUBE_HOSTNAME = 'www.youtube.com';
+const YOUTUBE_NOCOOKIE = 'youtube-nocookie.com';
 const DEFAULT_FRONTEND_URL = 'piped.video';
 
 
@@ -24,7 +25,13 @@ chrome.commands.onCommand.addListener(function(command) {
         chrome.storage.sync.get(['frontendUrl'], function(data) {
           let frontend = data.frontendUrl;
           console.log(frontend);
-          let newUrl = tab.url.replace(YOUTUBE_HOSTNAME, frontend);
+          let newUrl;
+          if (frontend === YOUTUBE_NOCOOKIE) {
+            newUrl = tab.url.replace(YOUTUBE_HOSTNAME + '/watch?v=', YOUTUBE_NOCOOKIE + '/embed/');
+          } else {
+            newUrl = tab.url.replace(YOUTUBE_HOSTNAME, frontend);
+          }
+          // let newUrl = tab.url.replace(YOUTUBE_HOSTNAME, frontend);
           chrome.tabs.update(tab.id, { url: newUrl });
         });
       }

--- a/src/main/content.js
+++ b/src/main/content.js
@@ -1,4 +1,5 @@
 const YOUTUBE_HOSTNAME = "www.youtube.com";
+const YOUTUBE_NOCOOKIE = 'youtube-nocookie.com';
 
 document.body.addEventListener("click", function(e) {
   if (
@@ -10,7 +11,13 @@ document.body.addEventListener("click", function(e) {
     let videoLink = e.target.closest('a[href^="/watch?"]').href;
     chrome.storage.sync.get(["frontendUrl"], function(data) {
       if (data.frontendUrl) {
-        let newLink = videoLink.replace(YOUTUBE_HOSTNAME, data.frontendUrl);
+        let newLink;
+        if (data.frontendUrl === YOUTUBE_NOCOOKIE) {
+          newLink = videoLink.replace(YOUTUBE_HOSTNAME + '/watch?v=', YOUTUBE_NOCOOKIE + '/embed/');
+        } else {
+          newLink = videoLink.replace(YOUTUBE_HOSTNAME, data.frontendUrl);
+        }
+        // let newLink = videoLink.replace(YOUTUBE_HOSTNAME, data.frontendUrl);
         chrome.runtime.sendMessage({ openTab: newLink });
       }
     });

--- a/src/main/options.html
+++ b/src/main/options.html
@@ -7,9 +7,16 @@
     </style>
 </head>
 <body>
-    <label for="frontendUrl">Alternative Frontend URL:</label>
-    <input type="text" id="frontendUrl" value="piped.video">
-    <button id="save">Save</button>
+    <p>
+        <label for="frontendUrl">Alternative Frontend URL:</label>
+        <input type="text" id="frontendUrl" value="piped.video">
+        <button id="save">Save</button>
+    </p>
+    <p>
+        If you do not know which alternative frontend to use, you can try indicating in the <strong>Alternative Frontend
+        URL</strong> field the address <code>youtube-nocookie.com</code><br>
+        This currently works by creating an embed of the video and serving it without advertising or other invasive technical means.
+    </p>
 
     <script src="options.js"></script>
 </body>


### PR DESCRIPTION
There is an alternative YouTube URL that serves cookie-free and currently ad-free videos (youtube-nocookie.com).
I modified the code a little to allow the user to choose that as the alternate frontend and - if detected - then the extension will further modify the url of the new tab to open because unlike YouTube (which uses /watch?v= after the main address) the alternate address needs "/embed/videocode" to work.

Nice idea and good extension, thank you for the work done 😄 
Enjoy!